### PR TITLE
Add Chrome extension to summarize Clova Note transcripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# clova_note_ext
+# Clova Note Summarizer Extension
+
+Chrome extension that reads the transcript from a [Naver Clova Note](https://clovanote.naver.com/) page,
+uses the ChatGPT API to summarize it, and returns a TODO list and schedule.
+
+## Setup
+
+1. Obtain an OpenAI API key from [https://platform.openai.com](https://platform.openai.com).
+2. Clone this repository and load the extension in Chrome:
+   - Open `chrome://extensions`.
+   - Enable **Developer mode**.
+   - Click **Load unpacked** and select this folder.
+3. Click the extension icon, enter your API key, and press **Save Key**.
+
+## Usage
+
+1. Open a Clova Note page that contains the transcription.
+2. Click the extension icon and press **Summarize & Plan**.
+3. The popup displays a summary along with a list of tasks and a proposed schedule.
+
+The transcript selector in `content.js` is generic and may need to be
+adjusted if the page structure changes.

--- a/content.js
+++ b/content.js
@@ -1,0 +1,11 @@
+// Extract transcript text from the page and respond to extension messages
+function extractTranscript() {
+  const candidate = document.querySelector('.transcript, .text, .note') || document.body;
+  return candidate.innerText;
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'GET_TRANSCRIPT') {
+    sendResponse({ transcript: extractTranscript() });
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 3,
+  "name": "Clova Note Summarizer",
+  "version": "1.0",
+  "description": "Summarize Naver Clova Note transcripts and plan tasks using ChatGPT API.",
+  "permissions": ["storage", "tabs"],
+  "host_permissions": ["https://api.openai.com/*"],
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://clovanote.naver.com/*"],
+      "js": ["content.js"]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "clova_note_ext",
+  "version": "1.0.0",
+  "description": "Chrome extension for summarizing Naver Clova Note transcripts using ChatGPT API.",
+  "scripts": {
+    "test": "echo 'No tests'"
+  }
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    body { width: 300px; font-family: sans-serif; }
+    #result { white-space: pre-wrap; margin-top: 10px; }
+    #apiKey { width: 100%; }
+  </style>
+</head>
+<body>
+  <input id="apiKey" type="password" placeholder="OpenAI API Key" />
+  <button id="saveKey">Save Key</button>
+  <button id="summarize">Summarize & Plan</button>
+  <div id="result"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,74 @@
+async function getApiKey() {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(['openaiKey'], (result) => {
+      resolve(result.openaiKey || '');
+    });
+  });
+}
+
+async function saveApiKey(key) {
+  return new Promise((resolve) => {
+    chrome.storage.sync.set({ openaiKey: key }, resolve);
+  });
+}
+
+async function getTranscript() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  return new Promise((resolve) => {
+    chrome.tabs.sendMessage(tab.id, { type: 'GET_TRANSCRIPT' }, (res) => {
+      resolve(res && res.transcript ? res.transcript : '');
+    });
+  });
+}
+
+async function callChatGPT(apiKey, transcript) {
+  const prompt = `You are an assistant that summarizes meeting transcripts. Summarize the following transcript, then provide a TODO list and a possible schedule.\n\n${transcript}`;
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }]
+    })
+  });
+  const data = await response.json();
+  return data.choices && data.choices[0] && data.choices[0].message
+    ? data.choices[0].message.content
+    : 'No response';
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const apiKeyInput = document.getElementById('apiKey');
+  const result = document.getElementById('result');
+  apiKeyInput.value = await getApiKey();
+
+  document.getElementById('saveKey').addEventListener('click', async () => {
+    await saveApiKey(apiKeyInput.value);
+    result.textContent = 'API key saved.';
+  });
+
+  document.getElementById('summarize').addEventListener('click', async () => {
+    const key = apiKeyInput.value.trim();
+    if (!key) {
+      result.textContent = 'Please enter API key.';
+      return;
+    }
+    await saveApiKey(key);
+    result.textContent = 'Extracting transcript...';
+    const transcript = await getTranscript();
+    if (!transcript) {
+      result.textContent = 'Transcript not found.';
+      return;
+    }
+    result.textContent = 'Contacting ChatGPT...';
+    try {
+      const summary = await callChatGPT(key, transcript);
+      result.textContent = summary;
+    } catch (e) {
+      result.textContent = 'Error: ' + e.message;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add manifest and content script to grab Clova Note transcripts
- Implement popup to call ChatGPT API and display summary, TODOs and schedule
- Provide setup instructions and npm test placeholder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06213d5948330b75af51e8cef686b