### PR TITLE
Add analysis and Q&A features to Clova Note extension

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,11 +1,69 @@
-// Extract transcript text from the page and respond to extension messages
-function extractTranscript() {
-  const candidate = document.querySelector('.transcript, .text, .note') || document.body;
-  return candidate.innerText;
+// Highlight difficult words and provide transcript to the extension
+
+// Fetch transcript from bundled temp.html
+async function extractTranscript() {
+  const res = await fetch(chrome.runtime.getURL('temp.html'));
+  const html = await res.text();
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  return doc.body.innerText;
+}
+
+// Highlight long English words and attach definitions
+function highlightDifficultWords() {
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  const nodes = [];
+  while (walker.nextNode()) {
+    nodes.push(walker.currentNode);
+  }
+
+  const difficult = new Set();
+  nodes.forEach((node) => {
+    const parts = node.nodeValue.split(/(\b)/);
+    if (!parts.some((p) => /[A-Za-z]{8,}/.test(p))) return;
+    const frag = document.createDocumentFragment();
+    parts.forEach((p) => {
+      if (/[A-Za-z]{8,}/.test(p)) {
+        const span = document.createElement('span');
+        span.textContent = p;
+        span.className = 'clova-ext-difficult-word';
+        span.dataset.word = p.toLowerCase();
+        span.title = '...';
+        span.style.textDecoration = 'underline dotted';
+        frag.appendChild(span);
+        difficult.add(p.toLowerCase());
+      } else {
+        frag.appendChild(document.createTextNode(p));
+      }
+    });
+    node.parentNode.replaceChild(frag, node);
+  });
+
+  difficult.forEach((word) => {
+    fetch(`https://api.dictionaryapi.dev/api/v2/entries/en/${word}`)
+      .then((r) => r.json())
+      .then((data) => {
+        const def = data[0]?.meanings?.[0]?.definitions?.[0]?.definition || 'No definition';
+        document.querySelectorAll(`span.clova-ext-difficult-word[data-word="${word}"]`).forEach((el) => {
+          el.title = def;
+        });
+      })
+      .catch(() => {
+        document.querySelectorAll(`span.clova-ext-difficult-word[data-word="${word}"]`).forEach((el) => {
+          el.title = 'No definition';
+        });
+      });
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', highlightDifficultWords);
+} else {
+  highlightDifficultWords();
 }
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.type === 'GET_TRANSCRIPT') {
-    sendResponse({ transcript: extractTranscript() });
+    extractTranscript().then((transcript) => sendResponse({ transcript }));
+    return true;
   }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -4,13 +4,16 @@
   "version": "1.0",
   "description": "Summarize Naver Clova Note transcripts and plan tasks using ChatGPT API.",
   "permissions": ["storage", "tabs"],
-  "host_permissions": ["https://api.openai.com/*"],
+  "host_permissions": [
+    "https://api.openai.com/*",
+    "https://api.dictionaryapi.dev/*"
+  ],
   "action": {
     "default_popup": "popup.html"
   },
   "content_scripts": [
     {
-      "matches": ["https://clovanote.naver.com/*"],
+      "matches": ["https://clovanote.naver.com/w/*/note-detail/*"],
       "js": ["content.js"]
     }
   ]

--- a/popup.html
+++ b/popup.html
@@ -5,13 +5,15 @@
   <style>
     body { width: 300px; font-family: sans-serif; }
     #result { white-space: pre-wrap; margin-top: 10px; }
-    #apiKey { width: 100%; }
+    #apiKey, #question { width: 100%; margin-top: 5px; }
   </style>
 </head>
 <body>
   <input id="apiKey" type="password" placeholder="OpenAI API Key" />
   <button id="saveKey">Save Key</button>
-  <button id="summarize">Summarize & Plan</button>
+  <button id="analyze">Analyze</button>
+  <input id="question" type="text" placeholder="Ask about the meeting" />
+  <button id="ask">Ask</button>
   <div id="result"></div>
   <script src="popup.js"></script>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -21,27 +21,35 @@ async function getTranscript() {
   });
 }
 
-async function callChatGPT(apiKey, transcript) {
-  const prompt = `You are an assistant that summarizes meeting transcripts. Summarize the following transcript, then provide a TODO list and a possible schedule.\n\n${transcript}`;
+async function callChatGPT(apiKey, prompt) {
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${apiKey}`
+      Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
       model: 'gpt-3.5-turbo',
-      messages: [{ role: 'user', content: prompt }]
-    })
+      messages: [{ role: 'user', content: prompt }],
+    }),
   });
   const data = await response.json();
-  return data.choices && data.choices[0] && data.choices[0].message
-    ? data.choices[0].message.content
-    : 'No response';
+  return data.choices?.[0]?.message?.content || 'No response';
+}
+
+async function summarize(apiKey, transcript) {
+  const prompt = `Summarize the following meeting transcript. Provide a summary and a TODO list.\n\n${transcript}`;
+  return callChatGPT(apiKey, prompt);
+}
+
+async function ask(apiKey, transcript, question) {
+  const prompt = `Transcript:\n${transcript}\n\nQuestion: ${question}`;
+  return callChatGPT(apiKey, prompt);
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
   const apiKeyInput = document.getElementById('apiKey');
+  const questionInput = document.getElementById('question');
   const result = document.getElementById('result');
   apiKeyInput.value = await getApiKey();
 
@@ -50,7 +58,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     result.textContent = 'API key saved.';
   });
 
-  document.getElementById('summarize').addEventListener('click', async () => {
+  document.getElementById('analyze').addEventListener('click', async () => {
     const key = apiKeyInput.value.trim();
     if (!key) {
       result.textContent = 'Please enter API key.';
@@ -63,10 +71,37 @@ document.addEventListener('DOMContentLoaded', async () => {
       result.textContent = 'Transcript not found.';
       return;
     }
+    result.textContent = 'Analyzing...';
+    try {
+      const summary = await summarize(key, transcript);
+      result.textContent = summary;
+    } catch (e) {
+      result.textContent = 'Error: ' + e.message;
+    }
+  });
+
+  document.getElementById('ask').addEventListener('click', async () => {
+    const key = apiKeyInput.value.trim();
+    const question = questionInput.value.trim();
+    if (!key) {
+      result.textContent = 'Please enter API key.';
+      return;
+    }
+    if (!question) {
+      result.textContent = 'Please enter a question.';
+      return;
+    }
+    await saveApiKey(key);
+    result.textContent = 'Extracting transcript...';
+    const transcript = await getTranscript();
+    if (!transcript) {
+      result.textContent = 'Transcript not found.';
+      return;
+    }
     result.textContent = 'Contacting ChatGPT...';
     try {
-      const summary = await callChatGPT(key, transcript);
-      result.textContent = summary;
+      const answer = await ask(key, transcript, question);
+      result.textContent = answer;
     } catch (e) {
       result.textContent = 'Error: ' + e.message;
     }


### PR DESCRIPTION
## Summary
- Highlight long English words in Clova Note pages and show definitions from a dictionary API
- Restrict extension to note-detail pages and read transcript from bundled temp.html
- Add "Analyze" and "Ask" actions in popup to summarize meetings or answer questions via ChatGPT

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be5aa587cc8330ab6bfe663822c1c0